### PR TITLE
fix: correct stylesheet file name

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>My Portfolio</title>
-  <link rel="stylesheet" href="stlyle.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 


### PR DESCRIPTION
The stylesheet was not loading due to a typo in the href value ("stlye.css" instead of "style.css").

Closes #6